### PR TITLE
Preprocessing errors

### DIFF
--- a/app/initializers/airbrake.js
+++ b/app/initializers/airbrake.js
@@ -15,7 +15,7 @@ function setupAirbrake(){
     user_agent: window.navigator.userAgent
   });
 
-  var preprocessor = config.preprocessor || function(err) { return err; };
+  var preprocessor = config.airbrake.preprocessor || function(err) { return err; };
   function pushError(err) {
     Airbrake.push(preprocessor(err));
   }

--- a/app/initializers/airbrake.js
+++ b/app/initializers/airbrake.js
@@ -15,13 +15,18 @@ function setupAirbrake(){
     user_agent: window.navigator.userAgent
   });
 
+  var preprocessor = config.preprocessor || function(err) { return err; };
+  function pushError(err) {
+    Airbrake.push(preprocessor(err));
+  }
+
   var originalOnError = Ember.onerror || Ember.K;
   Ember.onerror = function(err) { // any ember error
     originalOnError(err);
-    Airbrake.push(err);
+    pushError(err)
   };
   Ember.RSVP.on('error',function(err){ // any promise error
-    Airbrake.push(err);
+    pushError(err)
   });
   window.onerror = function(message, file, line, column, error){ // window general errors.
     if (message === 'Script error.') {
@@ -30,9 +35,9 @@ function setupAirbrake(){
     }
 
     if (error) {
-      Airbrake.push({error: error});
+      pushError({error: error})
     } else {
-      Airbrake.push({error: {
+      pushError({error: {
         message: message,
         fileName: file,
         lineNumber: line,


### PR DESCRIPTION
This adds support for registering an error preprocessor that can be used to try to convert anything thrown to sth. that's more valuable in the Airbrake UI, e.g.

``` js
function errorPreprocessor(err) {
  if (Ember.typeOf(err) !== 'error') {
    return JSON.stringify(err);
  } else {
    return err;
  }
}
```
