### PR TITLE
don't include extension in import

### DIFF
--- a/app/initializers/airbrake.js
+++ b/app/initializers/airbrake.js
@@ -1,6 +1,6 @@
 /* global Airbrake*/
 import Ember from "ember";
-import config from "../config/environment.js";
+import config from "../config/environment";
 
 var isSetup = false;
 


### PR DESCRIPTION
This changes

``` es6
import config from "../config/environment.js";
```

to

``` es6
import config from "../config/environment";
```

as the former breaks with sth. that's part of the ember-cli build chain and that recently updated (due to npm's and bower's missing `package.json.lock` / `bower.json.lock`) I don't specifically know which package that is though…
