### PR TITLE
Removes RSVP error handler

### DIFF
--- a/app/initializers/airbrake.js
+++ b/app/initializers/airbrake.js
@@ -28,9 +28,6 @@ function setupAirbrake(container) {
     originalOnError(err);
     pushError(err)
   };
-  Ember.RSVP.on('error',function(err){ // any promise error
-    pushError(err)
-  });
   window.onerror = function(message, file, line, column, error){ // window general errors.
     if (message === 'Script error.') {
       // Ignore.


### PR DESCRIPTION
Removes RSVP error handler as the default handler delegates to Ember.onerror anyway and Ember.RSVP has additional behaviour such as catching TransitionAborted errors.
