### PR TITLE
pin jquery to 2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.1.0",
     "ember-resolver": "~0.1.20",
-    "jquery": "^1.11.3",
+    "jquery": "2.1",
     "loader.js": "ember-cli/loader.js#3.4.0",
     "qunit": "~1.20.0",
     "airbrake-js-client": "airbrake-js#~0.5.8"


### PR DESCRIPTION
fixes a bad regex in ember that fails to recognize that jquery version is valid.
