### PR TITLE
Add getowner polyfill for Ember 2.3 support

### DIFF
--- a/addon/services/airbrake.js
+++ b/addon/services/airbrake.js
@@ -3,6 +3,7 @@ import getClient from '../utils/get-client';
 import setEnvironment from '../filters/environment';
 import loggerReporter from '../reporters/logger';
 import setSession from '../filters/session';
+import getOwner from 'ember-getowner-polyfill';
 
 export default Ember.Service.extend({
   init: function() {
@@ -32,7 +33,7 @@ export default Ember.Service.extend({
 
   // private
   _getClient() {
-    let config = this.container.lookupFactory('config:environment');
+    let config = getOwner(this).resolveRegistration('config:environment');
 
     let client = getClient(config, {
       reporters: [loggerReporter],

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-getowner-polyfill": "1.0.0",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
This adds the getOwner polyfill so that Ember 2.3 does not throw deprecations.
