### PR TITLE
Update usage of ember-getowner-polyfill to address deprecation

### DIFF
--- a/addon/services/airbrake.js
+++ b/addon/services/airbrake.js
@@ -3,7 +3,8 @@ import getClient from '../utils/get-client';
 import setEnvironment from '../filters/environment';
 import loggerReporter from '../reporters/logger';
 import setSession from '../filters/session';
-import getOwner from 'ember-getowner-polyfill';
+
+const { getOwner } = Ember;
 
 export default Ember.Service.extend({
   init: function() {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-getowner-polyfill": "1.0.0",
+    "ember-getowner-polyfill": "^1.2.2",
     "ember-try": "~0.0.8"
   },
   "keywords": [


### PR DESCRIPTION
Replaces `import getOwner` in favor of `Ember.getOwner`. For details, see issue: https://github.com/rwjblue/ember-getowner-polyfill/issues/5