### PR TITLE
Remover Ember.K so errors are not munched

### DIFF
--- a/app/instance-initializers/ember-cli-airbrake.js
+++ b/app/instance-initializers/ember-cli-airbrake.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import config from '../config/environment';
 
 function registerEmberOnError(notifyFn) {
-  let originalOnError = Ember.onerror || Ember.K;
+  let originalOnError = Ember.onerror || function() {};
+
   Ember.onerror = function(err) {
     originalOnError(err);
     notifyFn(err);


### PR DESCRIPTION
3.0 dropped support for`Ember.K`, which causes ember-cli-airbrake to much all exceptions thrown by Ember.  This should resolve things.