### PR TITLE
Fix incorrect airbrake-js package name

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     if (dep.isAbove('2.15.0')) {
       app.import('node_modules/airbrake-js/dist/client.min.js');
     } else {
-      app.import(app.bowerDirectory + '/airbrake-js/dist/client.min.js');
+      app.import(app.bowerDirectory + '/airbrake-js-client/dist/client.min.js');
     }
   }
 };


### PR DESCRIPTION
The airbrake-js library name now is airbrake-js-client, it caused the issue https://github.com/201-created/ember-cli-airbrake/issues/18